### PR TITLE
Feature/#44/project edit

### DIFF
--- a/src/components/EditProject/EditProject.tsx
+++ b/src/components/EditProject/EditProject.tsx
@@ -4,7 +4,6 @@ import NewpostEditor from "./MDEditor/MdeditorWriter";
 import NewpostImages from "./ImageUpload/ImageUpload";
 import { FaPlus, FaMinus } from "react-icons/fa";
 import { Button } from "../ui/button";
-import { CREATE_PROJECT } from "@/services/gql/createProject";
 import { useMutation, useQuery } from "@apollo/client";
 import { useSelectStacks } from "@/stores/selectStackType/selectStacksStore";
 import { useSelectTypes } from "@/stores/selectStackType/selectTypesStore";
@@ -16,6 +15,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useEditProject } from "@/stores/editProjectStore";
 import { GET_PROJECT_BY_ID } from "@/services/gql/getProjectDetailById";
+import { UPDATE_PROJECT } from "@/services/gql/updateProject";
 
 interface NewpostProps {
   title: string;
@@ -142,7 +142,7 @@ function NewpostRepresentativeImg({
   );
 }
 
-function CreateProjectButton({
+function EditProjectButton({
   title,
   bio,
   urls,
@@ -152,7 +152,7 @@ function CreateProjectButton({
   stackNames,
 }: NewpostProps) {
   const categoryKeys = categories.map((category) => getCategoryKey(category));
-  const [createProject] = useMutation(CREATE_PROJECT);
+  const [createProject] = useMutation(UPDATE_PROJECT);
   const router = useRouter();
 
   return (
@@ -174,7 +174,7 @@ function CreateProjectButton({
 
           if (response && response.data) {
             const projectData = response.data.createProject;
-            alert("프로젝트 등록이 완료되었습니다!");
+            alert("프로젝트 수정이 완료되었습니다!");
             console.log(projectData);
             router.push(`/project/${projectData.id}`);
           }
@@ -183,7 +183,7 @@ function CreateProjectButton({
         }
       }}
     >
-      프로젝트 등록
+      프로젝트 수정
     </Button>
   );
 }
@@ -274,7 +274,7 @@ export default function NewpostComponents() {
         imageUrls={imageUrls}
         setImageUrls={setImageUrls}
       />
-      <CreateProjectButton
+      <EditProjectButton
         title={title}
         bio={bio}
         urls={urls}

--- a/src/components/EditProject/EditProject.tsx
+++ b/src/components/EditProject/EditProject.tsx
@@ -17,18 +17,14 @@ import { useEditProject } from "@/stores/editProjectStore";
 import { GET_PROJECT_BY_ID } from "@/services/gql/getProjectDetailById";
 import { UPDATE_PROJECT } from "@/services/gql/updateProject";
 
-interface NewpostProps {
-  title: string;
-  bio: string;
-  urls: string[];
-  imageUrls: string[];
-  content: string;
+interface EditProjectProps {
+  projectId: number;
   categories: ProjectCategory[];
   stackNames: string[];
 }
 
 // 프로젝트 이름
-function NewpostName({
+function EditProjectName({
   title,
   setTitle,
 }: {
@@ -48,7 +44,7 @@ function NewpostName({
 }
 
 // 한 줄 소개글
-function NewpostOneline({
+function EditProjectOneline({
   bio,
   setBio,
 }: {
@@ -69,7 +65,7 @@ function NewpostOneline({
 }
 
 // 참고 링크
-function NewpostUrls({
+function EditProjectUrls({
   urls,
   setUrls,
 }: {
@@ -127,7 +123,7 @@ function NewpostUrls({
   );
 }
 
-function NewpostRepresentativeImg({
+function EditProjectRepresentativeImg({
   imageUrls,
   setImageUrls,
 }: {
@@ -143,25 +139,25 @@ function NewpostRepresentativeImg({
 }
 
 function EditProjectButton({
-  title,
-  bio,
-  urls,
-  imageUrls,
-  content,
+  projectId,
   categories,
   stackNames,
-}: NewpostProps) {
+}: EditProjectProps) {
   const categoryKeys = categories.map((category) => getCategoryKey(category));
-  const [createProject] = useMutation(UPDATE_PROJECT);
+  const [editProject] = useMutation(UPDATE_PROJECT);
   const router = useRouter();
+
+  const { title, bio, urls, imageUrls, content, setUrls } = useEditProject();
 
   return (
     <Button
       style={{ fontSize: "20px", padding: "20px" }}
       onClick={async () => {
+        setUrls(urls.filter((url) => url.trim() !== "" || url.trim() !== ""));
         try {
-          const response = await createProject({
+          const response = await editProject({
             variables: {
+              projectId,
               title,
               bio,
               urls,
@@ -170,13 +166,11 @@ function EditProjectButton({
               categories: categoryKeys,
               stackNames,
             },
+            fetchPolicy: "no-cache",
           });
-
           if (response && response.data) {
-            const projectData = response.data.createProject;
             alert("프로젝트 수정이 완료되었습니다!");
-            console.log(projectData);
-            router.push(`/project/${projectData.id}`);
+            router.push(`/project/${projectId}`);
           }
         } catch (err) {
           alert(err);
@@ -188,7 +182,7 @@ function EditProjectButton({
   );
 }
 
-export default function NewpostComponents() {
+export default function EditProjectComponents() {
   const {
     title,
     bio,
@@ -228,6 +222,7 @@ export default function NewpostComponents() {
 
   const { loading, error } = useQuery(GET_PROJECT_BY_ID, {
     variables: { projectId: parseInt(id as string) },
+    fetchPolicy: "no-cache",
     onCompleted: (fetchedData) => {
       const project = fetchedData.projectById;
       console.log(project);
@@ -259,27 +254,23 @@ export default function NewpostComponents() {
 
   return (
     <Styles.EditProjectContainer>
-      <NewpostName title={title} setTitle={setTitle} />
+      <EditProjectName title={title} setTitle={setTitle} />
       <Styles.EditProjectText>
         기술 스택 및 프로젝트 구분
       </Styles.EditProjectText>
       <SelectStackType />
-      <NewpostOneline bio={bio} setBio={setBio} />
-      <NewpostUrls urls={urls} setUrls={setUrls} />
+      <EditProjectOneline bio={bio} setBio={setBio} />
+      <EditProjectUrls urls={urls} setUrls={setUrls} />
       <Styles.EditProjectCard>
         <Styles.EditProjectText>프로젝트 소개</Styles.EditProjectText>
         <NewpostEditor content={content} setContent={setContent} />
       </Styles.EditProjectCard>
-      <NewpostRepresentativeImg
+      <EditProjectRepresentativeImg
         imageUrls={imageUrls}
         setImageUrls={setImageUrls}
       />
       <EditProjectButton
-        title={title}
-        bio={bio}
-        urls={urls}
-        imageUrls={imageUrls}
-        content={content}
+        projectId={parseInt(id as string)}
         categories={selectedTypes}
         stackNames={selectedStacks}
       />

--- a/src/components/EditProject/EditProject.tsx
+++ b/src/components/EditProject/EditProject.tsx
@@ -1,0 +1,288 @@
+import * as Styles from "./styles";
+import SelectStackType from "../SelectStackType/SelectStackType";
+import NewpostEditor from "./MDEditor/MdeditorWriter";
+import NewpostImages from "./ImageUpload/ImageUpload";
+import { FaPlus, FaMinus } from "react-icons/fa";
+import { Button } from "../ui/button";
+import { CREATE_PROJECT } from "@/services/gql/createProject";
+import { useMutation, useQuery } from "@apollo/client";
+import { useSelectStacks } from "@/stores/selectStackType/selectStacksStore";
+import { useSelectTypes } from "@/stores/selectStackType/selectTypesStore";
+import {
+  ProjectCategory,
+  getCategoryKey,
+} from "@/libs/enum/projectCategoryEnum";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { useEditProject } from "@/stores/editProjectStore";
+import { GET_PROJECT_BY_ID } from "@/services/gql/getProjectDetailById";
+
+interface NewpostProps {
+  title: string;
+  bio: string;
+  urls: string[];
+  imageUrls: string[];
+  content: string;
+  categories: ProjectCategory[];
+  stackNames: string[];
+}
+
+// 프로젝트 이름
+function NewpostName({
+  title,
+  setTitle,
+}: {
+  title: string;
+  setTitle: (title: string) => void;
+}) {
+  return (
+    <Styles.EditProjectCard>
+      <Styles.EditProjectNameInput
+        type="text"
+        placeholder="프로젝트 이름을 입력하세요"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      ></Styles.EditProjectNameInput>
+    </Styles.EditProjectCard>
+  );
+}
+
+// 한 줄 소개글
+function NewpostOneline({
+  bio,
+  setBio,
+}: {
+  bio: string;
+  setBio: (bio: string) => void;
+}) {
+  return (
+    <Styles.EditProjectCard>
+      <Styles.EditProjectText>한 줄 소개글</Styles.EditProjectText>
+      <Styles.EditProjectOnelineInput
+        type="text"
+        placeholder="한 줄 소개글"
+        value={bio}
+        onChange={(e) => setBio(e.target.value)}
+      ></Styles.EditProjectOnelineInput>
+    </Styles.EditProjectCard>
+  );
+}
+
+// 참고 링크
+function NewpostUrls({
+  urls,
+  setUrls,
+}: {
+  urls: string[];
+  setUrls: (urls: string[]) => void;
+}) {
+  const addLink = () => {
+    if (urls.length >= 3) {
+      alert("링크는 최대 3개까지 등록 가능합니다");
+      return;
+    }
+    setUrls([...urls, ""]);
+  };
+  const minusLink = (trg: number) => {
+    setUrls(urls.filter((_, idx) => idx !== trg));
+  };
+
+  return (
+    <Styles.EditProjectCard>
+      <Styles.EditProjectText>참고 링크</Styles.EditProjectText>
+      <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+        {urls.map((url, index) => (
+          <div key={index} style={{ display: "flex", gap: "10px" }}>
+            <Styles.EditProjectOnelineInput
+              type="text"
+              value={url}
+              placeholder="링크 입력 (https://github.com)"
+              onChange={(e) => {
+                const newLinks = [...urls];
+                newLinks[index] = e.target.value;
+                setUrls(newLinks);
+              }}
+            ></Styles.EditProjectOnelineInput>
+            {index === 0 ? (
+              <Styles.EditProjectLinkBtn
+                onClick={() => {
+                  addLink();
+                }}
+              >
+                <FaPlus />
+              </Styles.EditProjectLinkBtn>
+            ) : (
+              <Styles.EditProjectLinkBtn
+                onClick={() => {
+                  minusLink(index);
+                }}
+              >
+                <FaMinus />
+              </Styles.EditProjectLinkBtn>
+            )}
+          </div>
+        ))}
+      </div>
+    </Styles.EditProjectCard>
+  );
+}
+
+function NewpostRepresentativeImg({
+  imageUrls,
+  setImageUrls,
+}: {
+  imageUrls: string[];
+  setImageUrls: (imageUrls: string[]) => void;
+}) {
+  return (
+    <Styles.EditProjectCard>
+      <Styles.EditProjectText>대표 이미지</Styles.EditProjectText>
+      <NewpostImages imageUrls={imageUrls} setImageUrls={setImageUrls} />
+    </Styles.EditProjectCard>
+  );
+}
+
+function CreateProjectButton({
+  title,
+  bio,
+  urls,
+  imageUrls,
+  content,
+  categories,
+  stackNames,
+}: NewpostProps) {
+  const categoryKeys = categories.map((category) => getCategoryKey(category));
+  const [createProject] = useMutation(CREATE_PROJECT);
+  const router = useRouter();
+
+  return (
+    <Button
+      style={{ fontSize: "20px", padding: "20px" }}
+      onClick={async () => {
+        try {
+          const response = await createProject({
+            variables: {
+              title,
+              bio,
+              urls,
+              imageUrls,
+              content,
+              categories: categoryKeys,
+              stackNames,
+            },
+          });
+
+          if (response && response.data) {
+            const projectData = response.data.createProject;
+            alert("프로젝트 등록이 완료되었습니다!");
+            console.log(projectData);
+            router.push(`/project/${projectData.id}`);
+          }
+        } catch (err) {
+          alert(err);
+        }
+      }}
+    >
+      프로젝트 등록
+    </Button>
+  );
+}
+
+export default function NewpostComponents() {
+  const {
+    title,
+    bio,
+    urls,
+    imageUrls,
+    content,
+
+    setTitle,
+    setBio,
+    setUrls,
+    setContent,
+    setImageUrls,
+  } = useEditProject();
+  const {
+    stackToggle,
+    selectedStacks,
+    clickStackToggle,
+    clickStack,
+    resetStack,
+  } = useSelectStacks();
+  const { typeToggle, selectedTypes, clickTypeToggle, clickType, resetType } =
+    useSelectTypes();
+
+  useEffect(() => {
+    if (stackToggle) {
+      clickStackToggle();
+    }
+    resetStack();
+    if (typeToggle) {
+      clickTypeToggle();
+    }
+    resetType();
+  }, [resetStack, resetType]);
+
+  const router = useRouter();
+  const { id } = router.query;
+
+  const { loading, error } = useQuery(GET_PROJECT_BY_ID, {
+    variables: { projectId: parseInt(id as string) },
+    onCompleted: (fetchedData) => {
+      const project = fetchedData.projectById;
+      console.log(project);
+      setTitle(project.title);
+      console.log(project.bio);
+      setBio(project.bio);
+      setContent(project.content);
+      setImageUrls(project.imageUrls);
+      if (project.urls.length > 0) {
+        setUrls(project.urls);
+      }
+
+      if (project.stacks !== undefined) {
+        project.stacks.array.forEach((stack: string) => {
+          clickStack(stack);
+        });
+      }
+      if (project.categories !== undefined) {
+        project.categories.array.forEach((category: ProjectCategory) => {
+          clickType(category);
+        });
+      }
+    },
+  });
+
+  if (loading) return;
+  if (error)
+    return <p style={{ margin: "20px 20px" }}>Error: {error.message}</p>;
+
+  return (
+    <Styles.EditProjectContainer>
+      <NewpostName title={title} setTitle={setTitle} />
+      <Styles.EditProjectText>
+        기술 스택 및 프로젝트 구분
+      </Styles.EditProjectText>
+      <SelectStackType />
+      <NewpostOneline bio={bio} setBio={setBio} />
+      <NewpostUrls urls={urls} setUrls={setUrls} />
+      <Styles.EditProjectCard>
+        <Styles.EditProjectText>프로젝트 소개</Styles.EditProjectText>
+        <NewpostEditor content={content} setContent={setContent} />
+      </Styles.EditProjectCard>
+      <NewpostRepresentativeImg
+        imageUrls={imageUrls}
+        setImageUrls={setImageUrls}
+      />
+      <CreateProjectButton
+        title={title}
+        bio={bio}
+        urls={urls}
+        imageUrls={imageUrls}
+        content={content}
+        categories={selectedTypes}
+        stackNames={selectedStacks}
+      />
+    </Styles.EditProjectContainer>
+  );
+}

--- a/src/components/EditProject/ImageUpload/ImageUpload.tsx
+++ b/src/components/EditProject/ImageUpload/ImageUpload.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { MdUploadFile } from "react-icons/md";
+import { IoClose } from "react-icons/io5";
+import Image from "next/image";
+import * as Style from "./styles";
+
+export default function UploadBox({
+  imageUrls,
+  setImageUrls,
+}: {
+  imageUrls: string[];
+  setImageUrls: (imageUrls: string[]) => void;
+}) {
+  const [isActive, setActive] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
+  const handleDragEnter = () => setActive(true);
+  const handleDragLeave = (event: React.DragEvent<HTMLLabelElement>) => {
+    // 드래그가 완전히 벗어난 경우에만 setActive(false)를 호출
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      setActive(false);
+    }
+  };
+  const handleDragOver = (event: React.DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+  };
+
+  const setFileInfo = (file: File) => {
+    if (imageUrls.length >= 3) {
+      alert("이미지는 최대 3개까지 등록 가능합니다");
+      return;
+    }
+    const fileReader = new FileReader();
+    fileReader.readAsDataURL(file);
+    // 로딩이 완료되면 실행할 콜백 함수 등록
+    fileReader.onload = (e) => {
+      if (typeof e.target?.result === "string") {
+        setImageUrls([...imageUrls, e.target?.result as string]);
+      }
+    };
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    setActive(false);
+
+    const file = event.dataTransfer.files[0];
+    if (file) {
+      if (file.type.startsWith("image/")) {
+        setFileInfo(file);
+      } else {
+        alert("이미지 파일만 업로드할 수 있습니다.");
+      }
+    }
+  };
+
+  const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      if (file.type.startsWith("image/")) {
+        setFileInfo(file);
+      } else {
+        alert("이미지 파일만 업로드할 수 있습니다.");
+      }
+    }
+  };
+
+  const closeImage = (idx: number) => {
+    setImageUrls(imageUrls.filter((_, i) => i !== idx));
+  };
+
+  const openImagePreview = (src: string) => {
+    setSelectedImage(src);
+    setShowModal(true);
+  };
+
+  const closeImagePreview = () => {
+    setSelectedImage(null);
+    setShowModal(false);
+  };
+
+  const ImageWide = ({
+    src,
+    onClose,
+  }: {
+    src: string;
+    onClose: () => void;
+  }) => (
+    <Style.ModalOverlay
+      onClick={() => {
+        onClose();
+      }}
+    >
+      <Style.ModalImage src={src} alt="" />
+    </Style.ModalOverlay>
+  );
+
+  return (
+    <Style.ImageUploadContainer>
+      {imageUrls.map((img, index) => (
+        <Style.ImagePreview key={index}>
+          <Image
+            src={img}
+            onClick={() => {
+              openImagePreview(img);
+            }}
+            alt=""
+            layout="fill"
+          />
+          <Style.CloseButton
+            className="close-button"
+            onClick={() => {
+              closeImage(index);
+            }}
+          >
+            <IoClose />
+          </Style.CloseButton>
+
+          {showModal && selectedImage && (
+            <ImageWide src={selectedImage} onClose={closeImagePreview} />
+          )}
+        </Style.ImagePreview>
+      ))}
+      {/* 이미지 업로드 */}
+      <Style.ImageUpload
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        isActive={isActive}
+      >
+        <input
+          type="file"
+          className="file"
+          accept="image/*"
+          style={{ display: "none" }}
+          onChange={handleUpload}
+        />
+        <>
+          <MdUploadFile style={{ fontSize: "100px", marginBottom: "20px" }} />
+          <p>클릭 또는 드롭</p>
+        </>
+      </Style.ImageUpload>
+    </Style.ImageUploadContainer>
+  );
+}

--- a/src/components/EditProject/ImageUpload/styles.ts
+++ b/src/components/EditProject/ImageUpload/styles.ts
@@ -1,0 +1,84 @@
+import styled from "@emotion/styled";
+
+const lightgrey = "#d7e2eb";
+const grey = "#b2c0cc";
+
+export const ImageUploadContainer = styled.div`
+  display: flex;
+  white-space: nowrap;
+  gap: 20px;
+  justify-content: start;
+  align-items: center;
+  overflow-x: auto;
+`;
+
+interface DragProps {
+  isActive: boolean;
+}
+
+export const ImageUpload = styled.label<DragProps>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-width: 200px;
+  min-height: 200px;
+  align-items: center;
+  border: ${({ isActive }) =>
+    isActive ? `dashed 2px black` : `dashed 2px ${grey}`};
+  border-radius: 5px;
+  background-color: ${({ isActive }) => (isActive ? lightgrey : "white")};
+  cursor: pointer;
+  &:hover {
+    border-color: black;
+  }
+`;
+
+export const ImagePreview = styled.div`
+  width: 200px;
+  height: 200px;
+  position: relative;
+  cursor: pointer;
+
+  img {
+    object-fit: cover;
+  }
+
+  &:hover .close-button {
+    display: flex;
+  }
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  top: 3px;
+  right: 3px;
+  font-size: 30px;
+  background: transparent;
+  border: none;
+  color: black;
+  cursor: pointer;
+`;
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+`;
+
+export const ModalImage = styled.img`
+  max-width: 90%;
+  max-height: 90%;
+`;

--- a/src/components/EditProject/MDEditor/MdeditorWriter.tsx
+++ b/src/components/EditProject/MDEditor/MdeditorWriter.tsx
@@ -1,0 +1,161 @@
+import "@uiw/react-md-editor/markdown-editor.css";
+import "@uiw/react-markdown-preview/markdown.css";
+import Spinners from "@/components/Common/Spinners";
+import { uploadImage } from "@/pages/api/NewPost/mdeditor-image-upload";
+import dynamic from "next/dynamic";
+import { useState } from "react";
+import * as Style from "./styles";
+
+const MDEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
+
+function MDEditorWriter({
+  content,
+  setContent,
+}: {
+  content: string;
+  setContent: (title: string) => void;
+}) {
+  // const [value, setValue] = useState<string>("**프로젝트 소개를 입력하세요**");
+  const [loading, setLoading] = useState<boolean>(false);
+  const [isActive, setIsActive] = useState<boolean>(false);
+  const [cursorPosition, setCursorPosition] = useState<number>(0);
+
+  // 이미지 드래그 앤 드롭 관련 처리
+  const handleDragEnter = () => setIsActive(true);
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    // 드래그가 완전히 벗어난 경우에만 setActive(false)를 호출
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      setIsActive(false);
+    }
+  };
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsActive(false);
+
+    const file = event.dataTransfer.files[0];
+    if (file) {
+      if (file.type.startsWith("image/")) {
+        const fileReader = new FileReader();
+        fileReader.readAsDataURL(file);
+        fileReader.onload = async (e) => {
+          if (typeof e.target?.result === "string") {
+            setLoading(true);
+            const imageUrl = await uploadImage(file);
+            if (imageUrl) {
+              setContent(
+                content.substring(0, cursorPosition) +
+                  `\n![image](https://www.kookmin.ac.kr/content/05sub/style0005/images/sub/ui_5_col_image_3.jpg)\n` +
+                  content.substring(cursorPosition),
+              );
+            }
+            setLoading(false);
+          }
+        };
+      } else {
+        alert("이미지 파일만 업로드할 수 있습니다.");
+      }
+    }
+  };
+
+  // 이미지 붙여넣기 처리
+  const handlePaste = async (event: React.ClipboardEvent<HTMLDivElement>) => {
+    const clipboardData = event.clipboardData;
+    if (!clipboardData) {
+      return;
+    }
+
+    const clipboardItems = clipboardData.items;
+
+    if (clipboardItems[0].type.startsWith("image/")) {
+      const file = clipboardItems[0].getAsFile();
+
+      if (file) {
+        setLoading(true);
+        const imageUrl = await uploadImage(file);
+        if (imageUrl) {
+          setContent(
+            content.substring(0, cursorPosition) +
+              `\n![image](https://www.kookmin.ac.kr/content/05sub/style0005/images/sub/ui_5_col_image_2.jpg)\n` +
+              content.substring(cursorPosition),
+          );
+        }
+        setLoading(false);
+      }
+    }
+  };
+
+  // 입력 처리
+  const handleChange = (text?: string) => {
+    const updatedContent = text || "";
+    setContent(updatedContent);
+  };
+
+  const handleFocus = (event: React.FocusEvent<HTMLTextAreaElement>) => {
+    const position = event.target.selectionStart;
+    setCursorPosition(position);
+  };
+
+  const handleSelect = (event: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    const position = event.currentTarget.selectionStart;
+    setCursorPosition(position);
+  };
+
+  const handleMouseUp = (event: React.MouseEvent<HTMLTextAreaElement>) => {
+    const position = event.currentTarget.selectionStart;
+    setCursorPosition(position);
+  };
+
+  const handleKeyUp = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const position = event.currentTarget.selectionStart;
+    setCursorPosition(position);
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <Style.ImageDragDiv
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        isActive={isActive}
+      >
+        <MDEditor
+          height={600}
+          toolbarHeight={40}
+          visiableDragbar={false}
+          tabSize={2}
+          value={content}
+          onChange={handleChange}
+          onPaste={handlePaste}
+          textareaProps={{
+            onFocus: handleFocus,
+            onSelect: handleSelect,
+            onMouseUp: handleMouseUp,
+            onKeyUp: handleKeyUp,
+            disabled: loading,
+          }}
+        />
+        {loading && (
+          <div
+            style={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              zIndex: 9999,
+            }}
+          >
+            <Spinners />
+          </div>
+        )}
+      </Style.ImageDragDiv>
+    </div>
+  );
+}
+
+export default MDEditorWriter;

--- a/src/components/EditProject/MDEditor/styles.ts
+++ b/src/components/EditProject/MDEditor/styles.ts
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+interface DragProps {
+  isActive: boolean;
+}
+
+export const ImageDragDiv = styled.div<DragProps>`
+  align-items: center;
+
+  border-radius: 5px;
+`;

--- a/src/components/EditProject/styles.ts
+++ b/src/components/EditProject/styles.ts
@@ -1,0 +1,73 @@
+import styled from "@emotion/styled";
+
+const lightgrey = "#d7e2eb";
+const grey = "#b2c0cc";
+const black = "#09090B";
+
+export const EditProjectContainer = styled.div`
+  max-width: 1200px;
+  min-height: 100svh;
+  align-items: center;
+  padding: 20px 20px 20px 20px;
+  margin: auto;
+`;
+
+export const EditProjectCard = styled.div`
+  /* display: flex;
+  flex-direction: column; */
+  width: 100%;
+  margin-bottom: 20px;
+`;
+
+export const EditProjectText = styled.p`
+  margin: 0px 0px 10px;
+  font-size: 20px;
+`;
+
+export const EditProjectNameInput = styled.input`
+  border: none;
+  border-bottom: 2px solid ${lightgrey};
+  outline: none;
+  background: white;
+  height: 70px;
+  width: 100%;
+  font-size: 25px;
+  &:focus {
+    border-color: ${black};
+  }
+`;
+
+export const EditProjectOnelineInput = styled.input`
+  border: 2px solid ${grey};
+  border-radius: 5px;
+  background: white;
+  height: 50px;
+  width: 100%;
+  font-size: 20px;
+  padding-inline-start: 10px;
+  padding-inline-end: 10px;
+  outline-color: ${black};
+`;
+
+// 참고 링크
+export const EditProjectLinkContainer = styled.div``;
+
+export const EditProjectLinkBtn = styled.button`
+  border: 2px solid ${grey};
+  border-radius: 5px;
+  background-color: ${grey};
+  color: white;
+  min-height: 50px;
+  min-width: 50px;
+  font-size: 25px;
+  cursor: pointer;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &:hover {
+    border: 2px solid ${black};
+    background: ${black};
+  }
+`;

--- a/src/components/Newpost/Newpost.tsx
+++ b/src/components/Newpost/Newpost.tsx
@@ -17,11 +17,6 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 interface NewpostProps {
-  title: string;
-  bio: string;
-  urls: string[];
-  imageUrls: string[];
-  content: string;
   categories: ProjectCategory[];
   stackNames: string[];
 }
@@ -141,23 +136,18 @@ function NewpostRepresentativeImg({
   );
 }
 
-function CreateProjectButton({
-  title,
-  bio,
-  urls,
-  imageUrls,
-  content,
-  categories,
-  stackNames,
-}: NewpostProps) {
+function CreateProjectButton({ categories, stackNames }: NewpostProps) {
   const categoryKeys = categories.map((category) => getCategoryKey(category));
   const [createProject] = useMutation(CREATE_PROJECT);
   const router = useRouter();
+
+  const { title, bio, urls, imageUrls, content, setUrls } = useCreateProject();
 
   return (
     <Button
       style={{ fontSize: "20px", padding: "20px" }}
       onClick={async () => {
+        setUrls(urls.filter((url) => url.trim() !== "" || url.trim() !== ""));
         try {
           const response = await createProject({
             variables: {
@@ -233,11 +223,6 @@ export default function NewpostComponents() {
         setImageUrls={setImageUrls}
       />
       <CreateProjectButton
-        title={title}
-        bio={bio}
-        urls={urls}
-        imageUrls={imageUrls}
-        content={content}
         categories={selectedTypes}
         stackNames={selectedStacks}
       />

--- a/src/components/Project/Project.tsx
+++ b/src/components/Project/Project.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { useQuery } from "@apollo/client";
 import { GET_PROJECT_BY_ID } from "@/services/gql/getProjectDetailById";
 import { IProject, IProjectProps } from "@/libs/interface/iProject";
+import { useAuthStore } from "@/stores/authStore";
 
 function ProjectTittle({ project }: IProjectProps) {
   return <Styles.ProjectDetailTitle>{project.title}</Styles.ProjectDetailTitle>;
@@ -28,17 +29,6 @@ function ProjectStacksTypes({ project }: IProjectProps) {
             <Styles.TypeCard key={index}> {category}</Styles.TypeCard>
           ))}
     </Styles.StackTypeContainer>
-  );
-}
-
-function ProjectCategory({ project }: IProjectProps) {
-  const categoryList = project.categories;
-  return (
-    <div>
-      {categoryList === undefined
-        ? null
-        : categoryList.map((category, index) => <p key={index}>{category}</p>)}
-    </div>
   );
 }
 
@@ -126,6 +116,8 @@ export default function ProjectComponents() {
   const router = useRouter();
   const { id } = router.query;
 
+  const { user } = useAuthStore();
+
   const { data, loading, error } = useQuery(GET_PROJECT_BY_ID, {
     variables: { projectId: parseInt(id as string) },
   });
@@ -135,12 +127,17 @@ export default function ProjectComponents() {
     return <p style={{ margin: "20px 20px" }}>Error: {error.message}</p>;
   const project: IProject = data?.projectById;
 
+  console.log("123321123123123123132123123");
+  console.log(user);
+  console.log(user?.email);
+  console.log(user?.username);
+  console.log(data.authorName);
+
   return (
     <Styles.ProjectDetailContainer>
       <ProjectStacksTypes project={project} />
       <ProjectTittle project={project} />
       <ProjectIntroduction project={project} />
-      <ProjectCategory project={project} />
       <ProjectRepresentativeImages project={project} />
       <ProjectLinks project={project} />
       <MDEditorViewer project={project} />

--- a/src/components/Project/Project.tsx
+++ b/src/components/Project/Project.tsx
@@ -155,6 +155,7 @@ export default function ProjectComponents() {
 
   const { data, loading, error } = useQuery(GET_PROJECT_BY_ID, {
     variables: { projectId: parseInt(id as string) },
+    fetchPolicy: "no-cache",
   });
 
   if (loading) return;

--- a/src/components/Project/Project.tsx
+++ b/src/components/Project/Project.tsx
@@ -9,6 +9,8 @@ import { GET_PROJECT_BY_ID } from "@/services/gql/getProjectDetailById";
 import { IProject, IProjectProps } from "@/libs/interface/iProject";
 import { useAuthStore } from "@/stores/authStore";
 
+import { FaHeart, FaShare, FaEdit } from "react-icons/fa";
+
 function ProjectTittle({ project }: IProjectProps) {
   return <Styles.ProjectDetailTitle>{project.title}</Styles.ProjectDetailTitle>;
 }
@@ -38,6 +40,41 @@ function ProjectIntroduction({ project }: IProjectProps) {
       <Styles.ProjectDetailIntroduction>
         {project.bio}
       </Styles.ProjectDetailIntroduction>
+    </div>
+  );
+}
+
+function ProjectLikeShare({ project }: IProjectProps) {
+  const { user } = useAuthStore();
+
+  console.log("authorName: ", project.authorName);
+
+  return (
+    <div>
+      <div
+        style={{
+          marginTop: "20px",
+          display: "inline-flex",
+          justifyContent: "center",
+          alignItems: "center",
+          border: "solid 2px black",
+          borderRadius: "20px",
+          padding: "5px 15px 5px 15px",
+          gap: "15px",
+        }}
+      >
+        <button>
+          <FaHeart style={{ width: "26px", height: "26px" }} />
+        </button>
+        <button>
+          <FaShare style={{ width: "26px", height: "26px" }} />
+        </button>
+        {user?.data?.email === project.authorName ? (
+          <Link style={{ width: "100%" }} href={`/project/edit/${project.id}`}>
+            <FaEdit style={{ width: "26px", height: "26px" }} />
+          </Link>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -116,8 +153,6 @@ export default function ProjectComponents() {
   const router = useRouter();
   const { id } = router.query;
 
-  const { user } = useAuthStore();
-
   const { data, loading, error } = useQuery(GET_PROJECT_BY_ID, {
     variables: { projectId: parseInt(id as string) },
   });
@@ -127,12 +162,6 @@ export default function ProjectComponents() {
     return <p style={{ margin: "20px 20px" }}>Error: {error.message}</p>;
   const project: IProject = data?.projectById;
 
-  console.log("123321123123123123132123123");
-  console.log(user);
-  console.log(user?.email);
-  console.log(user?.username);
-  console.log(data.authorName);
-
   return (
     <Styles.ProjectDetailContainer>
       <ProjectStacksTypes project={project} />
@@ -141,6 +170,7 @@ export default function ProjectComponents() {
       <ProjectRepresentativeImages project={project} />
       <ProjectLinks project={project} />
       <MDEditorViewer project={project} />
+      <ProjectLikeShare project={project} />
     </Styles.ProjectDetailContainer>
   );
 }

--- a/src/libs/interface/iUser.ts
+++ b/src/libs/interface/iUser.ts
@@ -1,0 +1,12 @@
+export interface IUserData {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  // avatarUrl: string | null;
+}
+
+export interface IUser {
+  success: boolean;
+  data: IUserData | null;
+}

--- a/src/pages/project/edit/[id]/index.tsx
+++ b/src/pages/project/edit/[id]/index.tsx
@@ -1,0 +1,9 @@
+import EditProjectComponents from "@/components/EditProject/EditProject";
+
+export default function Project() {
+  return (
+    <div>
+      <EditProjectComponents />
+    </div>
+  );
+}

--- a/src/services/gql/getProjectDetailById.ts
+++ b/src/services/gql/getProjectDetailById.ts
@@ -12,6 +12,7 @@ export const GET_PROJECT_BY_ID = gql`
       isApproved
       categories
       stacks
+      authorName
     }
   }
 `;

--- a/src/services/gql/updateProject.ts
+++ b/src/services/gql/updateProject.ts
@@ -2,6 +2,7 @@ import { gql } from "@apollo/client";
 
 export const UPDATE_PROJECT = gql`
   mutation UpdateProject(
+    $projectId: ID!
     $title: String!
     $bio: String!
     $urls: [String]
@@ -11,7 +12,8 @@ export const UPDATE_PROJECT = gql`
     $stackNames: [String]
   ) {
     updateProject(
-      updateProjectRequest: {
+      projectUpdateRequest: {
+        projectId: $projectId
         title: $title
         bio: $bio
         urls: $urls

--- a/src/services/gql/updateProject.ts
+++ b/src/services/gql/updateProject.ts
@@ -1,0 +1,27 @@
+import { gql } from "@apollo/client";
+
+export const UPDATE_PROJECT = gql`
+  mutation UpdateProject(
+    $title: String!
+    $bio: String!
+    $urls: [String]
+    $imageUrls: [String]
+    $content: String!
+    $categories: [ProjectCategory]
+    $stackNames: [String]
+  ) {
+    updateProject(
+      updateProjectRequest: {
+        title: $title
+        bio: $bio
+        urls: $urls
+        imageUrls: $imageUrls
+        content: $content
+        categories: $categories
+        stackNames: $stackNames
+      }
+    ) {
+      id
+    }
+  }
+`;

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -3,10 +3,10 @@ import { create } from "zustand";
 interface AuthState {
   isLoggedIn: boolean;
   accessToken: string | null;
-  user: { id: number; email: string; role: string } | null;
+  user: { id: number; username: string; email: string; role: string } | null;
   login: (
     token: string,
-    user: { id: number; email: string; role: string },
+    user: { id: number; username: string; email: string; role: string },
   ) => void;
   logout: () => void;
   setAccessToken: (accessToken: string) => void;

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,13 +1,11 @@
+import { IUser } from "@/libs/interface/iUser";
 import { create } from "zustand";
 
 interface AuthState {
   isLoggedIn: boolean;
   accessToken: string | null;
-  user: { id: number; username: string; email: string; role: string } | null;
-  login: (
-    token: string,
-    user: { id: number; username: string; email: string; role: string },
-  ) => void;
+  user: IUser | null;
+  login: (token: string, user: IUser) => void;
   logout: () => void;
   setAccessToken: (accessToken: string) => void;
 }
@@ -18,7 +16,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   user: null,
 
   login: (token, user) => {
-    set({ isLoggedIn: true, user });
+    set({ isLoggedIn: true, user: user });
   },
 
   logout: () => {

--- a/src/stores/editProjectStore.ts
+++ b/src/stores/editProjectStore.ts
@@ -1,0 +1,42 @@
+import { ProjectCategory } from "@/libs/enum/projectCategoryEnum";
+import { create } from "zustand";
+
+export interface EditProject {
+  title: string;
+  bio: string;
+  urls: string[];
+  imageUrls: string[];
+  content: string;
+  category: ProjectCategory[];
+  stackNames: string[];
+  setTitle: (input: string) => void;
+  setBio: (input: string) => void;
+  setUrls: (input: string[]) => void;
+  setImageUrls: (input: string[]) => void;
+  setContent: (input: string) => void;
+}
+
+export const useEditProject = create<EditProject>((set) => ({
+  title: "",
+  bio: "",
+  urls: [""],
+  imageUrls: [],
+  content: "**프로젝트 소개를 입력하세요**",
+  category: [],
+  stackNames: [],
+  setTitle: (input: string) => {
+    set({ title: input });
+  },
+  setBio: (input: string) => {
+    set({ bio: input });
+  },
+  setUrls: (input: string[]) => {
+    set({ urls: input });
+  },
+  setImageUrls: (input: string[]) => {
+    set({ imageUrls: input });
+  },
+  setContent: (input: string) => {
+    set({ content: input });
+  },
+}));


### PR DESCRIPTION
## Overview

프로젝트 수정 기능 구현

### Related Issue

Issue Number : #44 

## Task Details

- GraphQL의 updateProject를 사용하여 프로젝트 수정 기능을 구현하였습니다.
- 프로젝트의 작성자(authorName)와 로그인한 사용자(userName)가 같은 경우 수정 버튼을 보여주도록 하였습니다.
- 수정 페이지에 들어가면 기존 프로젝트의 정보들이 연동되어 입력되어 있도록 하였습니다.
- 수정을 하고 프로젝트를 다시 보더라도 Apollo의 캐싱 기능 때문에 수정 사항이 반영되지 않아 getProjectDetailById와 updateProject에서 캐싱 기능을 사용하지 않도록 하였습니다.
- 링크를 입력하지 않은 경우 공백의 링크가 추가되는 오류를 수정하였습니다.

## Screenshots (Optional)

| ![image](https://github.com/user-attachments/assets/4c956dd3-aa54-42db-a133-fab0df36edfb) | ![image](https://github.com/user-attachments/assets/c6dd7d7b-ef8c-44ae-b900-8140e2e6654e) | ![image](https://github.com/user-attachments/assets/cc228c06-8e9e-492d-aedf-3e82344e7412) |
| - | - | - |

## Test Scope & Checklist (Optional)

> Please explain test scope, task, plan, method
- [x] 본인이 작성한 프로젝트에 들어간 경우 수정 버튼이 활성화된다.
- [x] 수정 버튼을 눌러 수정 페이지에 들어가면 기존 프로젝트 정보가 연동되어 입력되어 있다.
- [x] 수정 사항을 입력하고 "프로젝트 수정"버튼을 클릭하면 프로젝트 수정이 완료된다.

## Review Requirements

