### PR TITLE
Feature/#49/mypage

### DIFF
--- a/src/components/LoginModal/LoginModel.tsx
+++ b/src/components/LoginModal/LoginModel.tsx
@@ -172,7 +172,6 @@ const Modal: React.FC<ModalProps> = ({
           if (response.success) {
             setLoginState(token, response.data);
           }
-          console.log(response);
         } catch {
           console.log("error");
         }

--- a/src/components/LoginModal/LoginModel.tsx
+++ b/src/components/LoginModal/LoginModel.tsx
@@ -163,14 +163,14 @@ const Modal: React.FC<ModalProps> = ({
       const response = await login(email, password);
       console.log("response");
       console.log(response);
-      const token = response.data.accessToken;
+      // const token = response.data.accessToken;
       if (response.success) {
         setAccessToken(response.data.accessToken);
 
         try {
           const response = await getUserInfo();
           if (response.success) {
-            setLoginState(token, response.data);
+            setLoginState(response.data);
           }
         } catch {
           console.log("error");

--- a/src/components/Mypage/MyProjects/MyProjects.tsx
+++ b/src/components/Mypage/MyProjects/MyProjects.tsx
@@ -3,10 +3,12 @@ import { useSearchProject } from "@/stores/searchProjectStore";
 import { useQuery } from "@apollo/client";
 import { useEffect, useRef, useState } from "react";
 import MypageProjectCard from "@/components/ProjectCard/Mypage/MypageProjectCard";
+import { useAuthStore } from "@/stores/authStore";
 
 export default function MyProjectComponents() {
   const { page, hasNext, projects, setPage, setHasNext, setProjects, reset } =
     useSearchProject();
+  const { user } = useAuthStore();
 
   const SIZE = 5;
   const [isLoading, setIsLoading] = useState(true);
@@ -19,6 +21,7 @@ export default function MyProjectComponents() {
       title: "",
       stackNames: [],
       categories: [],
+      authorName: user?.username,
     },
   });
 

--- a/src/components/Mypage/MyProjects/MyProjects.tsx
+++ b/src/components/Mypage/MyProjects/MyProjects.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@apollo/client";
 import { useEffect, useRef, useState } from "react";
 import MypageProjectCard from "@/components/ProjectCard/Mypage/MypageProjectCard";
 import { useAuthStore } from "@/stores/authStore";
+import * as Styles from "./styles";
 
 export default function MyProjectComponents() {
   const { page, hasNext, projects, setPage, setHasNext, setProjects, reset } =
@@ -88,7 +89,7 @@ export default function MyProjectComponents() {
   };
 
   return (
-    <div>
+    <Styles.MypageMyProjectsContainer>
       {!isLoading && projects.length === 0 ? (
         <p style={{ marginTop: "20px", fontSize: "20px" }}>
           등록한 프로젝트가 없습니다.
@@ -114,6 +115,6 @@ export default function MyProjectComponents() {
           />
         </div>
       )}
-    </div>
+    </Styles.MypageMyProjectsContainer>
   );
 }

--- a/src/components/Mypage/MyProjects/styles.ts
+++ b/src/components/Mypage/MyProjects/styles.ts
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+
+export const MypageMyProjectsContainer = styled.div`
+  /* -ms-overflow-style: none; */
+  /* &::-webkit-scrollbar {
+    display: none;
+  } */
+  /* overflow: hidden; */
+  /* overflow-y: scroll; */
+`;

--- a/src/components/Mypage/MypageLayout.tsx
+++ b/src/components/Mypage/MypageLayout.tsx
@@ -16,8 +16,8 @@ function MypageMyInfo() {
         height={200}
         style={{ borderRadius: "50%" }}
       />
-      <Styles.MypageNickname>{user?.data?.username}</Styles.MypageNickname>
-      <Styles.MypageEmail>{user?.data?.email}</Styles.MypageEmail>
+      <Styles.MypageNickname>{user?.username}</Styles.MypageNickname>
+      <Styles.MypageEmail>{user?.email}</Styles.MypageEmail>
     </Styles.MypageMyinfo>
   );
 }

--- a/src/components/Mypage/MypageLayout.tsx
+++ b/src/components/Mypage/MypageLayout.tsx
@@ -72,6 +72,12 @@ type MypageLayoutProps = {
 };
 
 export default function MypageLayout({ children }: MypageLayoutProps) {
+  const { isLoggedIn } = useAuthStore();
+
+  if (!isLoggedIn) {
+    return null;
+  }
+
   return (
     <Styles.MypageContainer>
       <Styles.MypageSidebarContainer>

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -49,7 +49,7 @@ const Navigation: React.FC = () => {
           setAccessToken(newAccessToken);
           apiClient.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
           const userInfo = await getUserInfo();
-          login(newAccessToken, userInfo);
+          login(newAccessToken, userInfo.data);
         }
       } catch (error) {
         console.error("자동 로그인 실패:", error);

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -29,16 +29,19 @@ const Navigation: React.FC = () => {
   const [initialStep, setInitialStep] = useState<
     "main" | "signup" | "emailLogin" | "emailSignup"
   >("main");
-  const [isAuthLoading, setIsAuthLoading] = useState(true); // 로그인 관련 로딩 상태
+  // const [isAuthLoading, setIsAuthLoading] = useState(true); // 로그인 관련 로딩 상태
   const {
     isLoggedIn,
+    isAuthLoading,
     setAccessToken,
     login,
     logout: clearAuthState,
+    setIsAuthLoading,
   } = useAuthStore();
 
   // 자동 로그인 처리
   useEffect(() => {
+    setIsAuthLoading(true);
     const autoLogin = async () => {
       try {
         const refreshResponse = await reIssue();
@@ -49,7 +52,7 @@ const Navigation: React.FC = () => {
           setAccessToken(newAccessToken);
           apiClient.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
           const userInfo = await getUserInfo();
-          login(newAccessToken, userInfo.data);
+          login(userInfo.data);
         }
       } catch (error) {
         console.error("자동 로그인 실패:", error);
@@ -60,7 +63,7 @@ const Navigation: React.FC = () => {
     };
 
     autoLogin();
-  }, []);
+  }, [clearAuthState, login, setAccessToken]);
 
   const handleLogout = async () => {
     try {

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -21,6 +21,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 
 import { Button } from "../ui/button";
 import Link from "next/link";
+import { PopoverClose } from "@radix-ui/react-popover";
 
 const Navigation: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -143,20 +144,22 @@ const Navigation: React.FC = () => {
               </PopoverTrigger>
               <PopoverContent>
                 <Link href="/mypage">
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start"
-                    onClick={() => {}}
-                  >
-                    <Image
-                      style={{ cursor: "pointer", marginRight: "8px" }}
-                      src={"/icons/user_2.svg"}
-                      width={18}
-                      height={18}
-                      alt="mypage"
-                    />
-                    내 정보
-                  </Button>
+                  <PopoverClose>
+                    <Button
+                      variant="ghost"
+                      className="w-full justify-start"
+                      onClick={() => {}}
+                    >
+                      <Image
+                        style={{ cursor: "pointer", marginRight: "8px" }}
+                        src={"/icons/user_2.svg"}
+                        width={18}
+                        height={18}
+                        alt="mypage"
+                      />
+                      내 정보
+                    </Button>
+                  </PopoverClose>
                 </Link>
                 <Button variant="ghost" className="w-full justify-start">
                   <Image

--- a/src/components/Project/Project.tsx
+++ b/src/components/Project/Project.tsx
@@ -67,7 +67,7 @@ function ProjectLikeShare({ project }: IProjectProps) {
         <button>
           <FaShare style={{ width: "26px", height: "26px" }} />
         </button>
-        {user?.data?.email === project.authorName ? (
+        {user?.email === project.authorName ? (
           <Link style={{ width: "100%" }} href={`/project/edit/${project.id}`}>
             <FaEdit style={{ width: "26px", height: "26px" }} />
           </Link>

--- a/src/lib/interface/iUser.ts
+++ b/src/lib/interface/iUser.ts
@@ -1,12 +1,7 @@
-export interface IUserData {
-  id: number;
-  username: string;
-  email: string;
-  role: string;
-  // avatarUrl: string | null;
-}
-
 export interface IUser {
-  success: boolean;
-  data: IUserData | null;
+  id: number;
+  email: string;
+  username: string;
+  role: string;
+  avatarUrl: string | null;
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,9 +5,33 @@ import type { AppProps } from "next/app";
 import localFont from "next/font/local";
 import { ApolloProvider } from "@apollo/client";
 import client from "@/lib/apolloClient";
+import { useAuthStore } from "@/stores/authStore";
+import { useRouter } from "next/router";
+import { useEffect, useRef } from "react";
 const myFont = localFont({ src: "../fonts/PretendardVariable.woff2" });
 
 export default function App({ Component, pageProps }: AppProps) {
+  const { isLoggedIn } = useAuthStore();
+  const hasAlerted = useRef(false);
+  const router = useRouter();
+
+  // "/mypage는 로그인된 상태에서만 접근할 수 있음"
+  useEffect(() => {
+    const protectedRoutes = ["/mypage"];
+    const isProtectedRoute = protectedRoutes.some((route) =>
+      router.pathname.startsWith(route),
+    );
+
+    if (isProtectedRoute && !hasAlerted.current) {
+      hasAlerted.current = true;
+
+      if (!isLoggedIn) {
+        alert("로그인이 필요합니다");
+        router.replace("/");
+      }
+    }
+  }, [isLoggedIn, router]);
+
   return (
     <div className={myFont.className}>
       <Layout>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,26 +11,26 @@ import { useEffect, useRef } from "react";
 const myFont = localFont({ src: "../fonts/PretendardVariable.woff2" });
 
 export default function App({ Component, pageProps }: AppProps) {
-  const { isLoggedIn } = useAuthStore();
-  const hasAlerted = useRef(false);
+  const { isLoggedIn, isAuthLoading } = useAuthStore();
   const router = useRouter();
+  const hasAlerted = useRef(false);
 
-  // "/mypage는 로그인된 상태에서만 접근할 수 있음"
   useEffect(() => {
     const protectedRoutes = ["/mypage"];
     const isProtectedRoute = protectedRoutes.some((route) =>
       router.pathname.startsWith(route),
     );
 
-    if (isProtectedRoute && !hasAlerted.current) {
-      hasAlerted.current = true;
-
+    if (isProtectedRoute && !isAuthLoading) {
       if (!isLoggedIn) {
-        alert("로그인이 필요합니다");
-        router.replace("/");
+        if (!hasAlerted.current) {
+          hasAlerted.current = true;
+          alert("로그인이 필요합니다");
+          router.replace("/");
+        }
       }
     }
-  }, [isLoggedIn, router]);
+  }, [isLoggedIn, isAuthLoading, router]);
 
   return (
     <div className={myFont.className}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,7 +47,7 @@ export default function Home() {
     resetType();
   }, [resetStack, resetType]);
 
-  const SIZE = 5;
+  const SIZE = 36;
 
   const observerRef = useRef<HTMLDivElement>(null);
   const { data, loading, fetchMore, refetch } = useQuery(SEARCH_PROJECT, {

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,15 +1,22 @@
 import { useAuthStore } from "@/stores/authStore";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export default function Mypage() {
   const router = useRouter();
   const { isLoggedIn } = useAuthStore();
+  const hasAlerted = useRef(false);
 
   useEffect(() => {
-    if (isLoggedIn) {
-      router.replace("/mypage/myprojects");
-      console.log(isLoggedIn);
+    if (!hasAlerted.current) {
+      hasAlerted.current = true;
+
+      if (isLoggedIn) {
+        router.replace("/mypage/myprojects");
+      } else {
+        alert("로그인이 필요합니다");
+        router.replace("/");
+      }
     }
   }, [isLoggedIn, router]);
 

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,22 +1,14 @@
 import { useAuthStore } from "@/stores/authStore";
 import { useRouter } from "next/router";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 export default function Mypage() {
   const router = useRouter();
   const { isLoggedIn } = useAuthStore();
-  const hasAlerted = useRef(false);
 
   useEffect(() => {
-    if (!hasAlerted.current) {
-      hasAlerted.current = true;
-
-      if (isLoggedIn) {
-        router.replace("/mypage/myprojects");
-      } else {
-        alert("로그인이 필요합니다");
-        router.replace("/");
-      }
+    if (isLoggedIn) {
+      router.replace("/mypage/myprojects");
     }
   }, [isLoggedIn, router]);
 

--- a/src/pages/mypage/myprojects.tsx
+++ b/src/pages/mypage/myprojects.tsx
@@ -2,14 +2,24 @@ import React from "react";
 import MypageLayout from "@/components/Mypage/MypageLayout";
 import MyProjectComponents from "@/components/Mypage/MyProjects/MyProjects";
 import { useAuthStore } from "@/stores/authStore";
+import { css, Global } from "@emotion/react";
 
 const MyProjects: React.FC = () => {
   const { isLoggedIn } = useAuthStore();
   if (isLoggedIn) {
     return (
-      <MypageLayout>
-        <MyProjectComponents />
-      </MypageLayout>
+      <div>
+        <Global
+          styles={css`
+            &::-webkit-scrollbar {
+              display: none;
+            }
+          `}
+        />
+        <MypageLayout>
+          <MyProjectComponents />
+        </MypageLayout>
+      </div>
     );
   } else {
     return null;

--- a/src/services/gql/searchProject.ts
+++ b/src/services/gql/searchProject.ts
@@ -7,6 +7,7 @@ export const SEARCH_PROJECT = gql`
     $title: String
     $stackNames: [String]
     $categories: [ProjectCategory]
+    $authorName: String
   ) {
     searchProject(
       projectSearchRequest: {
@@ -15,6 +16,7 @@ export const SEARCH_PROJECT = gql`
         title: $title
         stackNames: $stackNames
         categories: $categories
+        authorName: $authorName
       }
     ) {
       count

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -5,7 +5,9 @@ interface AuthState {
   isLoggedIn: boolean;
   accessToken: string | null;
   user: IUser | null;
-  login: (token: string, user: IUser) => void;
+  isAuthLoading: boolean;
+  setIsAuthLoading: (loading: boolean) => void;
+  login: (user: IUser) => void;
   logout: () => void;
   setAccessToken: (accessToken: string) => void;
 }
@@ -14,8 +16,13 @@ export const useAuthStore = create<AuthState>((set) => ({
   isLoggedIn: false,
   accessToken: null,
   user: null,
+  isAuthLoading: true,
 
-  login: (token, user) => {
+  setIsAuthLoading: (loading: boolean) => {
+    set({ isAuthLoading: loading });
+  },
+
+  login: (user: IUser) => {
     set({ isLoggedIn: true, user: user });
   },
 


### PR DESCRIPTION
## Overview

마이페이지 구현(디테일)

### Related Issue

Issue Number : #49 

## Task Details

- 유저 아이콘을 클릭해 드롭다운을 띄우고 마이페이지로 이동하는 경우 드롭다운이 닫히도록 개선하였습니다. (Navigation.tsx에서 <Button>을 <PopoverClose>로 감쌈. 다른 버튼에도 적용 가능.)
- 마이페이지에서 로그인한 유저의 이름과 이메일을 보여주도록 설정하였습니다.
- login()함수와 autologin()함수에서 유저 정보를 저장할 때 데이터 형식이 달랐던 것을 통일하였습니다.
- 로그인하지 않은 상태로 주소창을 통해 /mypage, /mypage/myprojects 등을 통해 마이페이지에 접근하면 로그인이 필요하다는 문구와 함께 홈 화면으로 되돌아가도록 설정하였습니다. (useAuthStore에 isAuthLoading을 추가하여 구현 완료하였습니다.)
- emotion의 <Global>을 활용하여 무한스크롤에서 스크롤바가 보이지 않도록 적용하였습니다.

## Screenshots (Optional)

| 로그인하지 않은 상태로 마이페이지 접근 |
| - |
| ![image](https://github.com/user-attachments/assets/1b228cf8-96fd-4163-867c-7e5715229c5c) |


| 스크롤바가 숨겨진 모습 |
| - |
| ![image](https://github.com/user-attachments/assets/51a8f3eb-99e4-4353-b0b7-bd039214aba2) |



## Test Scope & Checklist (Optional)

- [x] 로그인하지 않은 상태로 마이페이지에 접근 시 안내 문구와 함께 홈 화면으로 이동된다.
- [x] 마이페이지의 "나의 프로젝트" 항목에서 스크롤바가 보이지 않는다.

## Review Requirements

